### PR TITLE
Move the asyncio.gather code directly inside the downloader class

### DIFF
--- a/binance_klines/cli.py
+++ b/binance_klines/cli.py
@@ -29,34 +29,7 @@ async def run_downloader(symbols, start_date, end_date, timeframe, output_dir):
     if missing_symbols:
         raise DownloaderException(f"Some symbols are not available on Binance: {missing_symbols}.")
 
-    try:
-        await asyncio.gather(
-            *[
-                _download_single_symbol(downloader, symbol, start_date, end_date, timeframe)
-                for symbol in symbols
-            ]
-        )
-        # This is the synchronous version (if you want to compare the performance)
-        # for symbol in symbols:
-        #     await _download_single_symbol(downloader, symbol, start_date, end_date, timeframe)
-    finally:
-        # Binance requires to release all resources with an explicit call to the .close()
-        # coroutine when you don't need the exchange instance anymore (at the end of your a
-        # sync coroutine).
-        await downloader.exchange.close()
-
-
-async def _download_single_symbol(downloader, symbol, start_date, end_date, timeframe):
-    LOGGER.info("Download in progress: %s", symbol)
-    output_filename = Path(f"{symbol.replace('/', '_')}-{timeframe}.csv")
-    try:
-        async for batch in downloader.fetch_ohlcv(
-            symbol, start_date, end_date, timeframe=timeframe
-        ):
-            utils.write_data_to_file(batch, output_filename)
-        LOGGER.info("Download finished: %s", symbol)
-    except DownloaderException as ex:
-        LOGGER.error("An error occurred while downloading %s: %s", symbol, ex)
+    await downloader.fetch_klines(symbols, start_date, end_date, timeframe)
 
 
 def _ask_confirmation() -> bool:

--- a/binance_klines/downloader.py
+++ b/binance_klines/downloader.py
@@ -3,13 +3,16 @@
 Fetch OHLCV klines from Binance.
 
 """
+import asyncio
 import datetime
 import logging
+from pathlib import Path
 
 import ccxt.async_support as ccxt  # link against the asynchronous version of ccxt
 import pytz
 from ccxt.base.errors import BadSymbol
 
+from binance_klines import utils
 from binance_klines.constants import AVAILABLE_TIMEFRAMES
 
 
@@ -31,9 +34,9 @@ class BinanceKLinesDownloader:
 
         self._instantiate_exchange()
 
-    async def fetch_ohlcv(
+    async def fetch_klines(
         self,
-        symbol: str,
+        symbols: list[str],
         start_date: datetime.datetime,
         end_date: datetime.datetime,
         timeframe: str = "1h",
@@ -41,7 +44,8 @@ class BinanceKLinesDownloader:
         """Download OHCLV data (klines).
 
         Args:
-            symbol (str): Symbol to download (e.g.: BTC/USDT). Must be a valid symbol for Binance.
+            symbols (list[str]): Symbols to download (e.g.: BTC/USDT). Must be valid symbols
+                for Binance.
             start_date (datetime.datetime): Start date (UTC timezone)
             end_date (datetime.datetime): End date (UTC timezone)
             timeframe (str, optional): Timeframe to download. Defaults to "1h".
@@ -69,11 +73,72 @@ class BinanceKLinesDownloader:
                 f"Invalid timeframe: {timeframe}. Available timeframes: {AVAILABLE_TIMEFRAMES}"
             )
 
+        try:
+            results = await asyncio.gather(
+                *[
+                    self._fetch_and_store_klines_for_symbol(symbol, start_date, end_date, timeframe)
+                    for symbol in symbols
+                ]
+            )
+            # This is the synchronous version (if you want to compare the performance)
+            # for symbol in symbols:
+            #     await _fetch_and_store_klines_for_symbol(downloader, symbol, start_date, end_date, timeframe)
+        finally:
+            # Binance requires to release all resources with an explicit call to the .close()
+            # coroutine when you don't need the exchange instance anymore (at the end of your a
+            # sync coroutine).
+            await self.exchange.close()
+
+        return results
+
+    async def _fetch_and_store_klines_for_symbol(self, symbol, start_date, end_date, timeframe):
+        """Download and store OHCLV data (klines) for a single symbol."""
+        output_filename = Path(f"{symbol.replace('/', '_')}-{timeframe}.csv")
+        batches = []
+        try:
+            async for batch in self._fetch_ohlcv_for_symbol(
+                symbol, start_date, end_date, timeframe=timeframe
+            ):
+                batches.append(batch)
+                utils.write_data_to_file(batch, output_filename)
+        except DownloaderException as ex:
+            self._logger.error("An error occurred while downloading %s: %s", symbol, ex)
+
+        return batches
+
+    async def _fetch_ohlcv_for_symbol(
+        self,
+        symbol: str,
+        start_date: datetime.datetime,
+        end_date: datetime.datetime,
+        timeframe: str = "1h",
+    ):
+        """Download OHCLV data (klines).
+
+        Args:
+            symbol (str): Symbol to download (e.g.: BTC/USDT). Must be a valid symbol for Binance.
+            start_date (datetime.datetime): Start date (UTC timezone)
+            end_date (datetime.datetime): End date (UTC timezone)
+            timeframe (str, optional): Timeframe to download. Defaults to "1h".
+
+        Yields:
+            List[int]: a list of OHLCV lines. Structure of each kline:
+                [
+                    1504541580000, // UTC timestamp in milliseconds, integer
+                    4235.4,        // (O)pen price, float
+                    4240.6,        // (H)ighest price, float
+                    4230.0,        // (L)owest price, float
+                    4230.7,        // (C)losing price, float
+                    37.72941911    // (V)olume (in terms of the base currency), float
+                ]
+
+        """
         # Convert UTC dates to timestamps in milliseconds (needed by Binance API)
         start_date_timestamp = int(start_date.timestamp()) * 1000  # Milliseconds
         end_date_timestamp = int(end_date.timestamp()) * 1000  # Milliseconds
 
         if self.exchange.has["fetchOrders"]:
+            self._logger.info("Download in progress: %s", symbol)
             since = start_date_timestamp
             while since < end_date_timestamp:
                 klines_batch = await self._fetch_ohlcv(
@@ -88,6 +153,7 @@ class BinanceKLinesDownloader:
                     break
 
                 yield klines_batch
+            self._logger.info("Download finished: %s", symbol)
 
     def get_markets(self):
         """Get the list of markets (symbols) available on Binance."""


### PR DESCRIPTION
This allows handling exceptions and closing the exchange directly in the instance methods.